### PR TITLE
Server editing bug fix - Properties not loading properly

### DIFF
--- a/api/server/ServerAPI.cs
+++ b/api/server/ServerAPI.cs
@@ -13,14 +13,14 @@
         /// <param name="serverName">The name of the server to be built</param>
         /// <param name="serverType">The server type to create the server as</param>
         /// <param name="serverVersion">The server version to build the server on</param>
-        public ServerBuilder Builder(string serverName, string serverType, string serverVersion)
+        public ServerBuilding Builder(string serverName, string serverType, string serverVersion)
             => new (serverName, serverType, serverVersion);
         
         /// <returns>
         /// Returns an instance of ServerStarting so that the user can start the selected server.
         /// </returns>
         /// <param name="name">The server name to use in order to locate the server to start</param>
-        public ServerStarter Starter(string name) => new (name);
+        public ServerStarting Starter(string name) => new (name);
         
         /// <returns>
         /// Returns an instance of ServerEditing so that the user can edit the selected server.

--- a/api/server/ServerBuilding.cs
+++ b/api/server/ServerBuilding.cs
@@ -17,7 +17,7 @@ namespace glowberry.api.server
     /// This class is responsible for providing an API for all types of server building operations
     /// that can be performed.
     /// </summary>
-    public class ServerBuilder
+    public class ServerBuilding
     {
         
         /// <summary>
@@ -58,7 +58,7 @@ namespace glowberry.api.server
         /// <param name="serverName">The name of the server to be built</param>
         /// <param name="serverType">The server type to create the server as</param>
         /// <param name="serverVersion">The server version to build the server on</param>
-        public ServerBuilder(string serverName, string serverType, string serverVersion)
+        public ServerBuilding(string serverName, string serverType, string serverVersion)
         {
             this.ServerVersion = serverVersion;
             this.ServerType = serverType;
@@ -121,8 +121,8 @@ namespace glowberry.api.server
             // If the server fails to build, delete the entire server section and remove its editor from the cache.
             else
             {
-                this.ServersSection.RemoveSection(this.ServerName);
                 GlobalEditorsCache.INSTANCE.Remove(this.ServerName);
+                this.ServersSection.RemoveSection(this.ServerName);
             }
         }
         

--- a/api/server/ServerEditing.cs
+++ b/api/server/ServerEditing.cs
@@ -86,7 +86,7 @@ namespace glowberry.api.server
         /// from its ServerInformation object.
         /// </summary>
         /// <returns>A Dictionary containing the current server settings.</returns>
-        public Dictionary<string, string> GetCurrentServerSettings() => Editor.GetBuffersCopy();
+        public Dictionary<string, string> GetCurrentServerSettings() => Editor.GetServerSettings();
         
         /// <returns>
         /// Returns the server section associated with the server name.

--- a/api/server/ServerStarting.cs
+++ b/api/server/ServerStarting.cs
@@ -9,7 +9,7 @@ namespace glowberry.api.server
     /// <summary>
     /// This class is responsible for providing an API used to start every supported server type.
     /// </summary>
-    public class ServerStarter
+    public class ServerStarting
     {
         
         /// <summary>
@@ -18,11 +18,11 @@ namespace glowberry.api.server
         private ServerEditing EditingAPI { get; }
         
         /// <summary>
-        /// Main constructor for the ServerStarter class. Takes in the server name and the server editor
+        /// Main constructor for the ServerStarting class. Takes in the server name and the server editor
         /// and sends the server starting instructions.
         /// </summary>
         /// <param name="serverName">The name of the server to operate on</param>
-        public ServerStarter(string serverName)
+        public ServerStarting(string serverName)
         {
             Section serverSection = FileSystem.GetFirstSectionNamed(serverName);
             this.EditingAPI = new ServerAPI().Editor(serverSection.SimpleName);

--- a/common/caches/GlobalEditorsCache.cs
+++ b/common/caches/GlobalEditorsCache.cs
@@ -58,7 +58,7 @@ namespace glowberry.common.caches
         /// <param name="serverSection">The server section to match the editor to</param>
         /// <returns>The ServerEditor matching the server name provided</returns>
         public ServerEditor? Get(Section serverSection) =>
-            ServerEditorsCache.FirstOrDefault(x => x.ServerSection.SectionFullPath.Equals(serverSection.SectionFullPath));
+            ServerEditorsCache.FirstOrDefault(x => x != null && x.ServerSection.SectionFullPath.Equals(serverSection.SectionFullPath));
         
         /// <summary>
         /// Adds a server editor to the cache, returning it afterwards.

--- a/common/server/builders/abstraction/AbstractServerBuilder.cs
+++ b/common/server/builders/abstraction/AbstractServerBuilder.cs
@@ -21,7 +21,7 @@ namespace glowberry.common.server.builders.abstraction
 {
     /// <summary>
     /// This interface implements contracts for the methods that should be implemented in each
-    /// ServerBuilder.
+    /// ServerBuilding.
     /// </summary>
     [SuppressMessage("ReSharper", "StringLiteralTypo")]
     [SuppressMessage("ReSharper", "AccessToDisposedClosure")]


### PR DESCRIPTION
Changed the way that the properties buffer works; It will now be filled on-demand with properties stemming from LoadProperties(), so that it doesn't need a mask.