### PR TITLE
Added the GlobalVersionManager used to register and provide the versions for every program.

### DIFF
--- a/GlowberryDLL.csproj
+++ b/GlowberryDLL.csproj
@@ -58,6 +58,7 @@
         <Compile Include="common\Constants.cs" />
         <Compile Include="common\factories\MappedServerTypes.cs" />
         <Compile Include="common\factories\ServerTypeMappingsFactory.cs" />
+        <Compile Include="common\GlobalVersionManager.cs" />
         <Compile Include="common\handlers\AbstractLoggingMessageProcessing.cs" />
         <Compile Include="common\handlers\ErrorCollection.cs" />
         <Compile Include="common\handlers\MessageProcessingOutputHandler.cs" />

--- a/common/GlobalVersionManager.cs
+++ b/common/GlobalVersionManager.cs
@@ -1,0 +1,28 @@
+﻿using System.Collections.Generic;
+using System.Configuration;
+
+namespace glowberry.common
+{
+    /// <summary>
+    /// This class is responsible providing each program with its version.
+    /// </summary>
+    public class GlobalVersionManager
+    {
+        
+        /// <summary>
+        /// The version mappings for each program.
+        /// </summary>
+        private static Dictionary<string, string> VersionMappings { get; } = new ()
+        {
+            {"launcher", "1.4.2"},
+            {"web", "1.0.0"}
+        };
+        
+        /// <summary>
+        /// Gets the version for the specified program based on the version mappings.
+        /// </summary>
+        /// <param name="program">The program name to get the version for</param>
+        /// <returns></returns>
+        public static string GetVersion(string program) => VersionMappings[program];
+    }
+}


### PR DESCRIPTION
- Added the GlobalVersionManager, to provide the versions for every program
- Added the VersionMappings indie the GlobalVersionManager; The programs will now have a version override in the configuration that will dictate if they should follow their own versioning or the DLL's, which allows me to not update the interface code every time the DLL is changed, and instead, manage it all from there.