### PR TITLE
Fixed a few issues with the MinecraftVersion comparison system and added the dll version to the global versioning manager

### DIFF
--- a/common/MinecraftVersion.cs
+++ b/common/MinecraftVersion.cs
@@ -18,6 +18,7 @@ namespace glowberry.common
         public MinecraftVersion(string rawVersion)
         {
             Version = rawVersion.Replace("?", "0");
+            Version = rawVersion.Split('-')[0];
             Version = rawVersion.Split('.').Length is var str and < 3 && str != 1
                 ? $"{Version}.0"
                 : Version;
@@ -62,19 +63,19 @@ namespace glowberry.common
                 return new Version(Version).CompareTo(new Version(other.Version));
             }
             
-            catch (ArgumentException) { } // There was an issue, needs further evaluation.
+            catch (SystemException) { } // There was an issue, needs further evaluation.
 
             // If the current version is the issue, then this one follows the other one.
             try
             {
                 Version _ = new(Version);
             }
-            catch (ArgumentException)
+            catch (SystemException)
             {
                 return -1;
             }
 
-            // If the other version is the issue, this this one precedes it.
+            // If the other version is the issue, this one precedes it.
             return 1;
         }
     }

--- a/common/configuration/GlobalVersionManager.cs
+++ b/common/configuration/GlobalVersionManager.cs
@@ -14,7 +14,8 @@ namespace glowberry.common.configuration
         private static Dictionary<string, string> VersionMappings { get; } = new ()
         {
             {"launcher", "1.5.0"},
-            {"web", "1.0.0"}
+            {"web", "1.0.0"},
+            {"dll", "1.2.1"}
         };
         
         /// <summary>


### PR DESCRIPTION
- Changed the exception catching scope of the versioning manager for the primary comparison from `ArgumentException` to `SystemException`. This way it also covers `FormatException`s
- Added the dll version into the GVM