### PR TITLE
Updated the versions and the server interactions, since we don't need to check for HasExited

### DIFF
--- a/api/server/ServerInteractions.cs
+++ b/api/server/ServerInteractions.cs
@@ -139,7 +139,7 @@ namespace glowberry.api.server
         public bool IsRunning()
         {
             Process proc = this.GetServerProcess();
-            return proc is { HasExited: false, ProcessName: "java" or "cmd" };
+            return proc is { ProcessName: "java" or "cmd" };
         }
 
         /// <summary>

--- a/common/configuration/GlobalVersionManager.cs
+++ b/common/configuration/GlobalVersionManager.cs
@@ -13,9 +13,9 @@ namespace glowberry.common.configuration
         /// </summary>
         private static Dictionary<string, string> VersionMappings { get; } = new ()
         {
-            {"launcher", "1.5.0"},
+            {"launcher", "1.5.1"},
             {"web", "1.0.0"},
-            {"dll", "1.2.2"}
+            {"dll", "1.2.3"}
         };
         
         /// <summary>


### PR DESCRIPTION
- Updated the launcher version to 1.5.1 and the dll to 1.2.3
- Since we don't actually need to check for `HasExited` to make sure a server has stopped, and rather just for the name of the process, removed that part and fixed issues in the console by doing so. (HasExited requires elevation)