### PR TITLE
Added surrounding quotation marks to the glowberry script path declaration to avoid issues with spaces

### DIFF
--- a/common/configuration/GlobalVersionManager.cs
+++ b/common/configuration/GlobalVersionManager.cs
@@ -22,7 +22,7 @@ namespace glowberry.common.configuration
         /// Gets the version for the specified program based on the version mappings.
         /// </summary>
         /// <param name="program">The program name to get the version for</param>
-        /// <returns></returns>
+        /// <returns>The version assigned for the program</returns>
         public static string GetVersion(string program) => VersionMappings[program];
     }
 }

--- a/utils/WindowsSchedulerUtils.cs
+++ b/utils/WindowsSchedulerUtils.cs
@@ -157,7 +157,7 @@ public class WindowsSchedulerUtils
                 )
 
                 echo Wi-Fi connection detected. Running Glowberry...
-                {Directory.GetCurrentDirectory()}\glowberry.exe start --server {serverName}
+                "{Directory.GetCurrentDirectory()}\glowberry.exe" start --server {serverName}
                 """.Trim();
     }
 }


### PR DESCRIPTION
The script will now produce:

```bat
@echo off
set "server=google.com"

:CHECK_CONNECTION
ping -n 1 %server% >nul
if errorlevel 1 (
    echo Waiting for a Wi-Fi connection...
    timeout /nobreak /t 5
    goto CHECK_CONNECTION
)

echo Wi-Fi connection detected. Running Glowberry...
"PATH\\glowberry.exe" start --server SERVERNAME
```